### PR TITLE
Filter should be removed from HTML for Perfomance #6

### DIFF
--- a/README.md
+++ b/README.md
@@ -156,7 +156,7 @@ $scope.$watchCollection('items', function () {
 
 In HTML:
 ```html
-<li ng-repeat="item in newitemsList | myComplexSortFilter"></li>
+<li ng-repeat="item in newitemsList"></li>
 ```
 
 ## Debugging:


### PR DESCRIPTION
Performance #6 mentions that we should not use filters for long array. 

In the good section, for HTML, filter should not have been there.
